### PR TITLE
Add AppEngine deployment of frontend

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -25,3 +25,15 @@ yarn run test
 ```
 
 For a detailed explanation on how things work, check out the [guide](http://vuejs-templates.github.io/webpack/) and [docs for vue-loader](http://vuejs.github.io/vue-loader).
+
+
+## Production Deployment
+
+Assuming you have `gcloud` installed and configured, here's how to deploy the code:
+    
+    yarn
+    yarn run build
+    gcloud --project getline-loans-demo app deploy
+
+You might want to pass --no-promote to `gcloud app deploy` and then migrate traffic manually between versions.
+

--- a/frontend/app.yaml
+++ b/frontend/app.yaml
@@ -2,6 +2,9 @@ runtime: python27
 api_version: 1
 threadsafe: true
 
+automatic_scaling:
+  min_idle_instances: 1
+
 handlers:
 - url: /
   static_files: dist/index.html

--- a/frontend/app.yaml
+++ b/frontend/app.yaml
@@ -1,0 +1,34 @@
+runtime: python27
+api_version: 1
+threadsafe: true
+
+handlers:
+- url: /
+  static_files: dist/index.html
+  upload: dist/index.html
+
+- url: /(.*)
+  static_files: dist/\1
+  upload: dist/(.*)
+
+skip_files:
+- ^(.*/)?app\.yaml
+- ^(.*/)?app\.yml
+- ^(.*/)?#.*#
+- ^(.*/)?.*~
+- ^(.*/)?.*\.py[co]
+- ^(.*/)?.*/RCS/.*
+- ^(.*/)?\..*
+- ^(.*/)?tests$
+- ^(.*/)?test$
+- ^test/(.*/)?
+- ^src/(.*/)?
+- ^COPYING.LESSER
+- ^README\..*
+- \.gitignore
+- ^\.git/.*
+- \.*\.lint$
+- ^fabfile\.py
+- ^testrunner\.py
+- ^grunt\.js
+- ^node_modules/(.*/)?


### PR DESCRIPTION
This will be the production deployment of the demo frontend.

It is already running on https://getline-loans-demo.appspot.com/. Adding a custom domain name is in progress.