### PR TITLE
Fix metabackend serving only a single loan in GetLoans.

### DIFF
--- a/metabackend/server/server.go
+++ b/metabackend/server/server.go
@@ -158,9 +158,12 @@ func (s *Server) GetLoans(ctx context.Context, req *pb.GetLoansRequest) (*pb.Get
 	cache := make([]*pb.LoanCache, len(loans))
 	errors := make([]error, len(loans))
 	wg := sync.WaitGroup{}
+
+	glog.Infof("GetLoans: %d results", len(loans))
 	for i, loan := range loans {
+		loan := loan
 		wg.Add(1)
-		go func(loan *model.LoanMetadata) {
+		go func(loan *model.LoanMetadata, i int) {
 			defer wg.Done()
 
 			parameters, err := s.Model.GetLoanParameters(ctx, network.ID, *loan.DeployedAddress)
@@ -177,7 +180,7 @@ func (s *Server) GetLoans(ctx context.Context, req *pb.GetLoansRequest) (*pb.Get
 				DeploymentState:   pb.LoanCache_DEPLOYED,
 			}
 			cache[i] = &c
-		}(&loan)
+		}(&loan, i)
 	}
 	wg.Wait()
 
@@ -185,7 +188,7 @@ func (s *Server) GetLoans(ctx context.Context, req *pb.GetLoansRequest) (*pb.Get
 		if err == nil {
 			continue
 		}
-		glog.Error("Could not get loan parameters: %v", err)
+		glog.Errorf("Could not get loan parameters: %v", err)
 	}
 
 	cacheNoErrors := []*pb.LoanCache{}


### PR DESCRIPTION
https://golang.org/doc/faq#closures_and_goroutines stikes again.