### PR TITLE
Added metabackend endpoint to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Public deployment
 
 For a work-in-progress webapp compatible with Metamask, see [demo.getline.in](https://demo.getline.in).
 
-Additionally, if you're developing your own application we invite you to use our [0.api.getline.in/](https://0.api.getline.in/) metabackend endpoint for easy access to latest and versioned smart contracts.
+Additionally, if you're developing your own application we invite you to use our [0.api.getline.in/](https://0.api.getline.in/) metabackend endpoint for easy access to the latest and versioned smart contracts. Keep in mind that the service on port 443 is currently only a [gRPCWeb](https://github.com/improbable-eng/grpc-web)-compatible endpoint and might cause problems for normal gRPC 
 
 This repository
 ---------------

--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ Getline Network
 
 This is the main repository for the Getline Distributed P2P Lending Platform. 
 
-Web interface
--------------
+Public deployment
+-----------------
 
 For a work-in-progress webapp compatible with Metamask, see [https://demo.getline.in](demo.getline.in).
+
+Additionally, if you're developing your own application we invite you to use our [https://0.api.getline.in/](0.api.getline.in) metabackend endpoint for easy access to latest and versioned smart contracts.
 
 This repository
 ---------------

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ This is the main repository for the Getline Distributed P2P Lending Platform.
 Public deployment
 -----------------
 
-For a work-in-progress webapp compatible with Metamask, see [https://demo.getline.in](demo.getline.in).
+For a work-in-progress webapp compatible with Metamask, see [demo.getline.in](https://demo.getline.in).
 
-Additionally, if you're developing your own application we invite you to use our [https://0.api.getline.in/](0.api.getline.in) metabackend endpoint for easy access to latest and versioned smart contracts.
+Additionally, if you're developing your own application we invite you to use our [0.api.getline.in/](https://0.api.getline.in/) metabackend endpoint for easy access to latest and versioned smart contracts.
 
 This repository
 ---------------


### PR DESCRIPTION
Since we already have the metabackend deployed and working, why not boast it a bit and allow any willing developers access to the goodies.