### PR TITLE
Add frontend build to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,11 +73,11 @@ jobs:
                 path: ~/project
             - restore_cache:
                 keys:
-                    - getlinets1-modules-{{ checksum "yarn.lock" }}
-                    - getlinets1-modules
+                    - getlinets2-modules-{{ checksum "yarn.lock" }}
+                    - getlinets2-modules
             - run: yarn
             - save_cache:
-                key: getlinets1-modules-{{ checksum "yarn.lock" }}
+                key: getlinets2-modules-{{ checksum "yarn.lock" }}
                 paths:
                     - node_modules/
             - run:
@@ -94,11 +94,11 @@ jobs:
                 path: ~/project
             - restore_cache:
                 keys:
-                    - frontend1-modules-{{ checksum "yarn.lock" }}
-                    - frontend1-modules
+                    - frontend2-modules-{{ checksum "yarn.lock" }}
+                    - frontend2-modules
             - run: yarn
             - save_cache:
-                key: frontend1-modules-{{ checksum "yarn.lock" }}
+                key: frontend2-modules-{{ checksum "yarn.lock" }}
                 paths:
                     - node_modules/
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,9 +63,33 @@ jobs:
                 path: ~/project/dapp/junit
             - store_artifacts:
                 path: ~/project/dapp/junit
+    
+    frontend_build:
+        docker:
+            - image: node:8.7
+        working_directory: ~/project/frontend
+        steps:
+            - checkout:
+                path: ~/project
+            - restore_cache:
+                keys:
+                    - frontend1-modules-{{ checksum "yarn.lock" }}
+                    - frontend1-modules
+            - run: yarn
+            - save_cache:
+                key: frontend1-modules-{{ checksum "yarn.lock" }}
+                paths:
+                    - node_modules/
+            - run:
+                command: yarn build
+            - store_artifacts:
+                path: ~/project/frontend/dist
 
 workflows:
     version: 2
+    frontend:
+        jobs:
+            - frontend_build
     dapp:
         jobs:
             - dapp_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,25 @@ jobs:
             - store_artifacts:
                 path: ~/project/dapp/junit
     
+    getline_ts_build:
+        docker:
+            - image: node:8.7
+        working_directory: ~/project/getline.ts
+        steps:
+            - checkout:
+                path: ~/project
+            - restore_cache:
+                keys:
+                    - getlinets1-modules-{{ checksum "yarn.lock" }}
+                    - getlinets1-modules
+            - run: yarn
+            - save_cache:
+                key: getlinets1-modules-{{ checksum "yarn.lock" }}
+                paths:
+                    - node_modules/
+            - run:
+                command: yarn tsc
+        
     frontend_build:
         docker:
             - image: node:8.7
@@ -89,7 +108,10 @@ workflows:
     version: 2
     frontend:
         jobs:
-            - frontend_build
+            - getline_ts_build
+            - frontend_build:
+                requires:
+                  - getline_ts_build
     dapp:
         jobs:
             - dapp_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,10 +85,10 @@ jobs:
             - run:
                 command: yarn tsc
             - run:
-                command: mkdir -p /tmp/workspace && cp -rv dist /tmp/workspace/getline.ts-dist
+                command: mkdir -p /tmp/workspace/getline.ts && cp -rv dist node_modules /tmp/workspace/getline.ts/
             - persist_to_workspace:
                 root: /tmp/workspace
-                paths: getline.ts-dist
+                paths: getline.ts
         
     frontend_build:
         docker:
@@ -109,7 +109,7 @@ jobs:
                 paths:
                     - node_modules/
             - run:
-                command: rm -rf ~/rpoject/getline.ts/dist && cp -rv /tmp/workspace/getline.ts-dist ~/project/getline.ts/dist
+                command:  cp -rv /tmp/workspace/getline.ts/* ~/project/getline.ts/
             - run:
                 command: yarn build
             - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
     
     getline_ts_build:
         docker:
-            - image: node:8.7
+            - image: getline/ci-frontend:latest
         working_directory: ~/project/getline.ts
         steps:
             - checkout:
@@ -87,7 +87,7 @@ jobs:
         
     frontend_build:
         docker:
-            - image: node:8.7
+            - image: getline/ci-frontend:latest
         working_directory: ~/project/frontend
         steps:
             - checkout:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,8 @@ jobs:
                 paths:
                     - node_modules/
             - run:
+                command: yarn generate
+            - run:
                 command: yarn tsc
         
     frontend_build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,11 @@ jobs:
                 command: yarn generate
             - run:
                 command: yarn tsc
+            - run:
+                command: mkdir -p /tmp/workspace && cp -rv dist /tmp/workspace/getline.ts-dist
+            - persist_to_workspace:
+                root: /tmp/workspace
+                paths: getline.ts-dist
         
     frontend_build:
         docker:
@@ -92,6 +97,8 @@ jobs:
         steps:
             - checkout:
                 path: ~/project
+            - attach_workspace:
+                at: /tmp/workspace
             - restore_cache:
                 keys:
                     - frontend2-modules-{{ checksum "yarn.lock" }}
@@ -101,6 +108,8 @@ jobs:
                 key: frontend2-modules-{{ checksum "yarn.lock" }}
                 paths:
                     - node_modules/
+            - run:
+                command: rm -rf ~/rpoject/getline.ts/dist && cp -rv /tmp/workspace/getline.ts-dist ~/project/getline.ts/dist
             - run:
                 command: yarn build
             - store_artifacts:

--- a/production/ci/frontend/Dockerfile
+++ b/production/ci/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.7
+FROM node:9.2-stretch
 
 RUN set -e -x ;\
     apt-get -y update ;\

--- a/production/ci/frontend/Dockerfile
+++ b/production/ci/frontend/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:8.7
+
+RUN set -e -x ;\
+    apt-get -y update ;\
+    apt-get -y install protobuf-compiler ;\
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This doesn't yet get stored as a publicly accessible artifact for testing, but it's a good first step - as it runs the typescript compiler for both getline.ts and the frontend.