### PR TITLE
Switch to asynchronous eth.network and eth.account

### DIFF
--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -12,10 +12,12 @@ let waiters: Array<Waiter> = [];
 export default {
   init: () => {
     api = new Client(METABACKEND_URL, METABACKEND_NETWORK);
-    // Wake up sleepers waiting for API.
-    for (let i = 0; i < waiters.length; i++) {
-      waiters[i](api);
-    }
+    api.initialize().then(()=>{
+        // Wake up sleepers waiting for API.
+        for (let i = 0; i < waiters.length; i++) {
+          waiters[i](api);
+        }
+    });
   },
   instance: (): Promise<Client> => {
     return new Promise<Client>((resolve, reject) => {

--- a/getline.ts/src/blockchain.ts
+++ b/getline.ts/src/blockchain.ts
@@ -138,13 +138,32 @@ export class GetlineBlockchain {
         } else {
             console.log("getline.ts: using user-injected provider")
         }
-
         this.web3 = new Web3(provider);
-        const currentNetwork = this.web3.version.network;
-        if (currentNetwork != this.network) {
-            throw new Error(`web3 is connected to wrong network (got ${currentNetwork}, expected ${this.network})`)
-        }
-        this.web3.eth.defaultAccount = this.web3.eth.accounts[0];
+    }
+
+    public async initialize(): Promise<void> {
+        return new Promise<void>((resolve, reject)=>{
+            this.web3.version.getNetwork((e, network)=>{
+                if (e != null) {
+                    reject(new Error("Could not initialize getline.ts: " + e));
+                    return;
+                }
+                if (network != this.network) {
+                    reject(new Error(`Connected to wrong network (got ${network}, expected ${this.network})`));
+                    return;
+                }
+                this.web3.eth.getAccounts((e, accounts)=>{
+                    if (e != null) {
+                        reject(new Error("Could not initialize getline.ts: " + e));
+                    }
+                    if (accounts.length < 1) {
+                        reject(new Error("No accounts available"));
+                    }
+                    this.web3.eth.defaultAccount = accounts[0];
+                    resolve();
+                });
+            });
+        });
     }
 
     /**

--- a/getline.ts/src/client.ts
+++ b/getline.ts/src/client.ts
@@ -26,6 +26,7 @@ export class Client {
     private metabackend: MetabackendClient;
     private network: string;
     private blockchain: GetlineBlockchain;
+    private initialized: boolean;
 
     /**
      * Token that is used for collateral and loans in the demo.
@@ -34,6 +35,7 @@ export class Client {
 
     /**
      * Creates a new Getline client.
+     * The .initialize() method must be called before first use.
      *
      * @param metabackend Address of metabackend. Production address is
      *                    `https://0.api.getline.in`.
@@ -48,9 +50,35 @@ export class Client {
         this.network = network;
         this.blockchain = new GetlineBlockchain(this.metabackend, network, provider);
         this.testToken = new PrintableToken(this.blockchain, "0x02c9ccaa1034a64e3a83df9ddce30e6d4bc40515");
+        this.initialized = false;
     }
 
+    /**
+     * Initialize the API client and connect to the blockchain.
+     * This must be called before any other method.
+     */
+    public async initialize(): Promise<void> {
+        if (this.initialized) {
+            console.error("getline.ts client was initialized twice - ignoring.");
+            return;
+        }
+        await this.blockchain.initialize();
+        this.initialized = true;
+    }
+    
+    // TODO(q3k): Remove this after demo, require explicit initialization instead.
+    private async initializeIfNeeded(): Promise<void> {
+        if (this.initialized) {
+            return;
+        }
+        console.error("getline.ts client was not explicitely initialized - this will be deprecated in the future");
+        return this.initialize();
+    }
+
+
     public async currentUser(): Promise<Address> {
+        await this.initializeIfNeeded();
+
         return this.blockchain.coinbase();
     }
 
@@ -73,6 +101,8 @@ export class Client {
      */
     public async newLoan(description: string, amount: BigNumber, interestPermil: number,
                          fundraisingEnd: moment.Moment, paybackEnd: moment.Moment): Promise<Loan> {
+        await this.initializeIfNeeded();
+
         // TODO(q3k) change this when we're not on rinkeby and we have a better loan SC
         if (this.network != "4") {
             throw new Error("cannot place loan on non-rinkeby chains");
@@ -120,6 +150,8 @@ export class Client {
      * @returns Loan identifier by shortId.
      */
     public async loan(shortId: string): Promise<Loan> {
+        await this.initializeIfNeeded();
+
         let req = new pb.GetLoansRequest();
         req.setNetworkId(this.network);
         req.setShortId(shortId);
@@ -141,6 +173,8 @@ export class Client {
      * @returns Loans owned by `owner`.
      */
     public async loansByOwner(owner: Address): Promise<Array<Loan>> {
+        await this.initializeIfNeeded();
+
         let req = new pb.GetLoansRequest();
         req.setNetworkId(this.network);
         req.setOwner(owner.proto());

--- a/getline.ts/src/example.ts
+++ b/getline.ts/src/example.ts
@@ -9,6 +9,7 @@ function delay(ms: number): Promise<void> {
 
 let main = async() => {
     let c = new Client("https://0.api.getline.in", "4");
+    await c.initialize();
     let user = await c.currentUser();
     console.log("user: " + user.ascii);
 


### PR DESCRIPTION
This means that we can no longer initialize the entire getline.ts client
library in the constructor. We add an async initialize() method for
explicit initializations, and a crutch to call it from existing methods
if the client hasn't yet been explicitely initialized.

Adding this method is actually quite serendipitous, as it will let us
have a single point where clients can call it to get exceptions thrown
if something is wrong with the blockchain we're connected to (no web3
provider, no account unlocked, wrong network, etc). We'll have to add a
separate class of errors for that.