### PR TITLE
Enable type declaration emit from getline.ts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,9 +81,7 @@ jobs:
                 paths:
                     - node_modules/
             - run:
-                command: yarn generate
-            - run:
-                command: yarn tsc
+                command: yarn build
             - run:
                 command: mkdir -p /tmp/workspace/getline.ts && cp -rv dist node_modules /tmp/workspace/getline.ts/
             - persist_to_workspace:

--- a/frontend/src/api/errors.ts
+++ b/frontend/src/api/errors.ts
@@ -1,5 +1,5 @@
 import { EventsProvider } from '../events';
-import { ProviderLocked, ProviderOnUnsupportedNetwork, ProviderInitializeError } from '../../../getline.ts';
+import { ProviderLocked, ProviderOnUnsupportedNetwork, ProviderInitializationError } from '../../../getline.ts';
 
 export function handleInitError(error, events: EventsProvider) {
   switch (error.constructor) {
@@ -11,7 +11,7 @@ export function handleInitError(error, events: EventsProvider) {
       console.log("Metamask on unsupported network.")
       events.unsupportedNetwork();
       break;
-    case ProviderInitializeError:
+    case ProviderInitializationError:
       console.log("Metamask error (is it installed?): " + error);
       events.metamaskNotInstalled();
       break;

--- a/frontend/src/api/metabackend.ts
+++ b/frontend/src/api/metabackend.ts
@@ -1,6 +1,6 @@
 const METABACKEND: { URL: string; NETWORK: string } =
   {
-    URL: 'http://0.api.getline.in',
+    URL: 'https://0.api.getline.in',
     NETWORK: '4',
   }
 export default METABACKEND;

--- a/frontend/src/components/borrow/MyLoans.vue
+++ b/frontend/src/components/borrow/MyLoans.vue
@@ -16,6 +16,20 @@ import MyLoanTile from './MyLoanTile.vue';
 import API, {Loan, LoanState} from '../../api';
 import {BigNumber} from 'bignumber.js';
 
+interface ViewLoan {
+  // Data received immediately.
+  description: string;
+  interestPermil: number;
+  loanState: LoanState;
+
+  // Data from promises.
+  amountGathered?: string;
+  amountWanted?: string;
+  isCollateralCollection?: boolean;
+  isFundraising?: boolean;
+  tokenSymbol?: string;
+};
+
 const Component = Vue.extend({
   name: 'MyLoans',
   components: {
@@ -34,10 +48,10 @@ const Component = Vue.extend({
         description,
         parameters: {interestPermil},
         blockchainState: {loanState}
-      }) => ({
+      }): ViewLoan => ({
         description,
         interestPermil,
-        loanState
+        loanState,
       }));
 
       const amountsWantedPromises: Promise<BigNumber>[] =
@@ -60,13 +74,13 @@ const Component = Vue.extend({
         }) => loanToken.humanize(amountGathered));
       const amountsGathered: BigNumber[] = await Promise.all(amountsGatheredPromises);
 
-      const loanTokenSymbolPromises: Promise<String>[] =
+      const loanTokenSymbolPromises: Promise<string>[] =
         loans.map(({
           parameters: {
             loanToken
           }
         }) => loanToken.symbol());
-      const loanTokenSymbols: String[] = await Promise.all(loanTokenSymbolPromises);
+      const loanTokenSymbols: string[] = await Promise.all(loanTokenSymbolPromises);
 
       for (var i = 0; i < _loans.length; ++i) {
         _loans[i].amountWanted = amountsWanted[i].toString();

--- a/frontend/src/components/borrow/MyLoans.vue
+++ b/frontend/src/components/borrow/MyLoans.vue
@@ -44,7 +44,7 @@ const Component = Vue.extend({
       let currentUser = await api.currentUser();
       let loans = await api.loansByOwner(currentUser);
       await Promise.all(loans.map(loan => loan.updateStateFromBlockchain()));
-      let _loans = loans.map(({
+      let _loans: ViewLoan[] = loans.map(({
         description,
         parameters: {interestPermil},
         blockchainState: {loanState}

--- a/getline.ts/README.md
+++ b/getline.ts/README.md
@@ -25,3 +25,9 @@ Sample usage
 ------------
 
 See `src/example.ts`.
+
+Building
+--------
+
+    yarn
+    yarn build

--- a/getline.ts/package.json
+++ b/getline.ts/package.json
@@ -29,8 +29,7 @@
   },
   "scripts": {
     "doc": "typedoc -out doc/ src typings node_modules/web3-typescript-typings/index.d.ts",
-    "generate": "protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --js_out=import_style=commonjs,binary:src/generated --ts_out=service=true:src/generated -I ../pb/ ../pb/*.proto",
-    "tsc": "tsc",
+    "build": "sh scripts/build.sh",
     "test": "mocha -r ts-node/register test/**/*.ts",
     "lint": "tslint -c tslint.json 'src/**/*.ts' -e src/generated/**/*"
   },

--- a/getline.ts/scripts/build.sh
+++ b/getline.ts/scripts/build.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e -x
+
+# 1) Generate protos into src/generated
+protoc --plugin=protoc-gen-ts=./node_modules/.bin/protoc-gen-ts --js_out=import_style=commonjs,binary:src/generated --ts_out=service=true:src/generated -I ../pb/ ../pb/*.proto
+
+# 2) Compile typescript into dist/
+tsc
+
+# 3) Copy over src/generated js/d.ts bundles (ie. protofiles that are not services) into dist/generated (because tsc doesn't do that for us...)
+mkdir -p dist/generated
+for f in src/generated/*.js; do
+    base=$(basename "${f}" .js)
+    cp -v "src/generated/${base}.js" dist/generated
+    cp -v "src/generated/${base}.d.ts" dist/generated
+done

--- a/getline.ts/src/blockchain.ts
+++ b/getline.ts/src/blockchain.ts
@@ -8,7 +8,7 @@ import {MetabackendClient, pb} from "./metabackend";
 
 const logger = debug("getline.ts:blockchain");
 
-class UserVisibleError extends Error {
+export class UserVisibleError extends Error {
     constructor(message: string) {
         super(message);
         Object.setPrototypeOf(this, new.target.prototype);

--- a/getline.ts/src/index.ts
+++ b/getline.ts/src/index.ts
@@ -1,3 +1,3 @@
 export {Client} from "./client";
 export {Loan, LoanState} from "./loan";
-export {ProviderLocked, ProviderOnUnsupportedNetwork, ProviderInitializationError} from "./blockchain";
+export {ProviderLocked, ProviderOnUnsupportedNetwork, ProviderInitializationError, UserVisibleError} from "./blockchain";

--- a/getline.ts/src/index.ts
+++ b/getline.ts/src/index.ts
@@ -1,3 +1,4 @@
 export {Client} from "./client";
 export {Loan, LoanState} from "./loan";
-export {ProviderLocked, ProviderOnUnsupportedNetwork, ProviderInitializationError, UserVisibleError} from "./blockchain";
+export {ProviderLocked, ProviderOnUnsupportedNetwork,
+    ProviderInitializationError, UserVisibleError} from "./blockchain";

--- a/getline.ts/tsconfig.json
+++ b/getline.ts/tsconfig.json
@@ -2,9 +2,8 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es2015",
-    "declaration": false,
+    "declaration": true,
     "outDir": "./dist",
-    "allowJs": true,
     "experimentalDecorators": true,
     "strict": true
   },

--- a/production/ci/integration/getline.ts/Dockerfile
+++ b/production/ci/integration/getline.ts/Dockerfile
@@ -11,5 +11,4 @@ WORKDIR /app/getline.ts
 
 RUN set -e -x ;\
     yarn ;\
-    yarn generate ;\
-    yarn tsc
+    yarn build


### PR DESCRIPTION
This causes us to catch a few bugs on the interaction between getline.ts and the frontend.

While we're at it, we also switch the metabackend endpoint to its' TLS version.

Interestingly, after disabling `allowJs` (to enable `declarations`), tsc does not copy over `src/generated/*.{js,d.ts}` to `dist/`. I am copying them over manually, but this seems hacky.