### PR TITLE
Implement loan querying by state

### DIFF
--- a/getline.ts/src/blockchain.ts
+++ b/getline.ts/src/blockchain.ts
@@ -341,7 +341,7 @@ export class GetlineBlockchain {
 
                 this.web3.eth.getCode(address, (e2, code) => {
                     if (!code || code.length < 3) {
-                        reject(new Error("Contract did not get stored"));
+                        reject(new Error("Contract did not get stored: " + e2));
                         return;
                     }
 

--- a/getline.ts/tsconfig.json
+++ b/getline.ts/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
+    "lib": ["es2016", "dom"],
     "target": "es2015",
     "declaration": true,
     "outDir": "./dist",

--- a/metabackend/model/ethereum.go
+++ b/metabackend/model/ethereum.go
@@ -75,14 +75,3 @@ func (b *blockchainRemote) get(ctx context.Context, networkId, contractName stri
 	bound := bind.NewBoundContract(address, parsed, b.blockchain, b.blockchain)
 	return bound, nil
 }
-
-func (b *blockchainRemote) ValidLoan(ctx context.Context, networkId string, address common.Address) (string, error) {
-	return "", nil
-	//=_, err := b.GetLoan(ctx, network, address)
-	//=if err != nil {
-	//=	// TODO(q3k): Do not leak error messages to caller.
-	//=	return err.Error(), nil
-	//=}
-	//=// TODO(q3k): Validate if given address contains known loan bytecode.
-	//=return "", nil
-}

--- a/metabackend/model/ethereum.go
+++ b/metabackend/model/ethereum.go
@@ -76,26 +76,13 @@ func (b *blockchainRemote) get(ctx context.Context, networkId, contractName stri
 	return bound, nil
 }
 
-func (b *blockchainRemote) GetLoan(ctx context.Context, networkId string, address common.Address) (*DeployedLoanParameters, error) {
-	loanContract, err := b.get(ctx, networkId, "Loan", address)
-	if err != nil {
-		return nil, fmt.Errorf("getting Loan contract failed: %v", err)
-	}
-
-	d := DeployedLoanParameters{}
-	errs := []error{}
-	errs = append(errs, loanContract.Call(nil, &d.BorrowedToken, "borrowedToken"))
-	errs = append(errs, loanContract.Call(nil, &d.CollateralToken, "collateralToken"))
-	errs = append(errs, loanContract.Call(nil, &d.AmountWanted, "amountWanted"))
-	errs = append(errs, loanContract.Call(nil, &d.Borrower, "borrower"))
-	errs = append(errs, loanContract.Call(nil, &d.InterestPermil, "interestPermil"))
-	errs = append(errs, loanContract.Call(nil, &d.FundraisingBlocksCount, "fundraisingBlocksCount"))
-	errs = append(errs, loanContract.Call(nil, &d.PaybackBlocksCount, "paybackBlocksCount"))
-	for _, err := range errs {
-		if err != nil {
-			return nil, fmt.Errorf("calling getter failed: %v", err)
-		}
-	}
-
-	return &d, nil
+func (b *blockchainRemote) ValidLoan(ctx context.Context, networkId string, address common.Address) (string, error) {
+	return "", nil
+	//=_, err := b.GetLoan(ctx, network, address)
+	//=if err != nil {
+	//=	// TODO(q3k): Do not leak error messages to caller.
+	//=	return err.Error(), nil
+	//=}
+	//=// TODO(q3k): Validate if given address contains known loan bytecode.
+	//=return "", nil
 }

--- a/metabackend/model/model.go
+++ b/metabackend/model/model.go
@@ -16,14 +16,11 @@ package model
 
 import (
 	"fmt"
-	"math/big"
 
-	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/jmoiron/sqlx"
 	_ "github.com/lib/pq"
 
 	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/getline-network/getline/metabackend/util"
 	"github.com/getline-network/getline/pb"
 )
 
@@ -96,44 +93,4 @@ func (m *Model) Transaction() (*sqlx.Tx, error) {
 func (m *Model) InitializeSchema() error {
 	_, err := m.dbConn.Exec(schema)
 	return err
-}
-
-type Loan struct {
-	model *Model
-
-	Parameters struct {
-		BorrowedToken          ethcommon.Address
-		CollateralToken        ethcommon.Address
-		AmountWanted           *big.Int
-		Borrower               ethcommon.Address
-		InterestPermil         uint16
-		FundraisingBlocksCount *big.Int
-		PaybackBlocksCount     *big.Int
-	}
-	Metadata struct {
-		NetworkID       string
-		ShortID         string
-		Borrower        ethcommon.Address
-		Description     string
-		DeployedAddress ethcommon.Address
-	}
-}
-
-func (d *Loan) ProtoParameters() *pb.LoanParameters {
-	res := pb.LoanParameters{
-		CollateralToken:        util.ProtoAddress(d.Parameters.CollateralToken.Hex()),
-		LoanToken:              util.ProtoAddress(d.Parameters.BorrowedToken.Hex()),
-		Liege:                  util.ProtoAddress(d.Parameters.Borrower.Hex()),
-		AmountWanted:           d.Parameters.AmountWanted.String(),
-		InterestPermil:         uint32(d.Parameters.InterestPermil),
-		FundraisingBlocksCount: d.Parameters.FundraisingBlocksCount.String(),
-		PaybackBlocksCount:     d.Parameters.PaybackBlocksCount.String(),
-	}
-	return &res
-}
-
-func (m *Model) NewLoan() *Loan {
-	return &Loan{
-		model: m,
-	}
 }

--- a/metabackend/model/sql_model.go
+++ b/metabackend/model/sql_model.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/golang/glog"
+	"github.com/jmoiron/sqlx"
 	"github.com/teris-io/shortid"
 	"golang.org/x/net/context"
 )
@@ -57,7 +59,7 @@ CREATE TABLE loan_metadata (
 
 	primary key(loan_metadata_id),
 	unique(shortid),
-	unique(deployed_address)
+	unique(network, deployed_address)
 );
 `
 
@@ -66,187 +68,184 @@ func (m *Model) InitializeSchema() error {
 	return err
 }
 
-// tableDeployedLoanParameters is a dumb cache of the parameters of a Loan
-// contract on the blockchain.
-type tableDeployedLoanParameters struct {
-	Version int64  `db:"version"`
-	Network string `db:"network"`
-	Address []byte `db:"address"`
+type fieldsLoanMetadata struct {
+	// Identification
+	ID      int64  `db:"meta_loan_metadata_id"`
+	ShortID string `db:"meta_shortid"`
+	Network string `db:"meta_network"`
 
-	BorrowedToken          []byte `db:"borrowed_token"`
-	CollateralToken        []byte `db:"collateral_token"`
-	AmountWanted           string `db:"amount_wanted"`
-	Borrower               []byte `db:"borrower"`
-	InterestPermil         uint16 `db:"interest_permil"`
-	FundraisingBlocksCount string `db:"fundraising_blocks_count"`
-	PaybackBlocksCount     string `db:"payback_blocks_count"`
+	// Metadata
+	DeployedAddress []byte `db:"meta_deployed_address"`
+	Borrower        []byte `db:"meta_borrower"`
+	Description     string `db:"meta_description"`
 }
 
-// Object returns an application-level DeployedLoanParameters from a
-// tableDeployedLoanParameters.
-func (t *tableDeployedLoanParameters) Object(m *Model) (*DeployedLoanParameters, error) {
+type fieldsDeployedLoanParameters struct {
+	// Identification
+	Network string `db:"params_network"`
+	Version int64  `db:"params_version"`
+	Address []byte `db:"params_address"`
+
+	// Parameters
+	BorrowedToken          []byte `db:"params_borrowed_token"`
+	CollateralToken        []byte `db:"params_collateral_token"`
+	AmountWanted           string `db:"params_amount_wanted"`
+	Borrower               []byte `db:"params_borrower"`
+	InterestPermil         uint16 `db:"params_interest_permil"`
+	FundraisingBlocksCount string `db:"params_fundraising_blocks_count"`
+	PaybackBlocksCount     string `db:"params_payback_blocks_count"`
+}
+
+type joinedLoansMetadataParameters struct {
+	fieldsLoanMetadata
+	fieldsDeployedLoanParameters
+}
+
+func (m *Model) selectJoinedLoansMetadataParameters(ctx context.Context, keys []string, args []interface{}) (data []joinedLoansMetadataParameters, err error) {
+	query := `
+		SELECT
+			meta.loan_metadata_id AS meta_loan_metadata_id,
+			meta.shortid AS meta_shortid,
+			meta.network AS meta_network,
+			meta.deployed_address AS meta_deployed_address,
+			meta.borrower AS meta_borrower,
+			meta.description AS meta_description,
+
+			params.borrowed_token AS params_borrowed_token,
+			params.collateral_token AS params_collateral_token,
+			params.amount_wanted AS params_amount_wanted,
+			params.interest_permil AS params_interest_permil,
+			params.fundraising_blocks_count AS params_fundraising_blocks_count,
+			params.payback_blocks_count AS params_payback_blocks_count
+		FROM loan_metadata AS meta
+		JOIN deployed_loan_parameters AS params
+			ON meta.deployed_address = params.address
+			AND meta.network = params.network
+	` + buildWhere(keys)
+	err = m.dbConn.SelectContext(ctx, &data, query, args...)
+	return data, err
+}
+
+func (t *fieldsDeployedLoanParameters) Fill(l *Loan) error {
 	var amountWanted, fundraisingBlocksCount, paybackBlocksCount *big.Int
 	var ok bool
 
 	if amountWanted, ok = new(big.Int).SetString(t.AmountWanted, 10); !ok {
-		return nil, fmt.Errorf("invalid amount_wanted value")
+		return fmt.Errorf("invalid amount_wanted value")
 	}
 	if fundraisingBlocksCount, ok = new(big.Int).SetString(t.FundraisingBlocksCount, 10); !ok {
-		return nil, fmt.Errorf("invalid fundraising_blocks_count value")
+		return fmt.Errorf("invalid fundraising_blocks_count value")
 	}
 	if paybackBlocksCount, ok = new(big.Int).SetString(t.PaybackBlocksCount, 10); !ok {
-		return nil, fmt.Errorf("invalid payback_blocks_count value")
+		return fmt.Errorf("invalid payback_blocks_count value")
 	}
 
-	return &DeployedLoanParameters{
-		BorrowedToken:          ethcommon.BytesToAddress(t.BorrowedToken),
-		CollateralToken:        ethcommon.BytesToAddress(t.CollateralToken),
-		Borrower:               ethcommon.BytesToAddress(t.Borrower),
-		InterestPermil:         t.InterestPermil,
-		AmountWanted:           amountWanted,
-		FundraisingBlocksCount: fundraisingBlocksCount,
-		PaybackBlocksCount:     paybackBlocksCount,
-	}, nil
+	l.Parameters.BorrowedToken = ethcommon.BytesToAddress(t.BorrowedToken)
+	l.Parameters.CollateralToken = ethcommon.BytesToAddress(t.CollateralToken)
+	l.Parameters.Borrower = ethcommon.BytesToAddress(t.Borrower)
+	l.Parameters.InterestPermil = t.InterestPermil
+	l.Parameters.AmountWanted = amountWanted
+	l.Parameters.FundraisingBlocksCount = fundraisingBlocksCount
+	l.Parameters.PaybackBlocksCount = paybackBlocksCount
+
+	return nil
 }
 
-func (m *Model) GetDeployedLoanParametersByAddress(ctx context.Context, networkId string, address ethcommon.Address) (*tableDeployedLoanParameters, error) {
-	dest := []tableDeployedLoanParameters{}
-	err := m.dbConn.SelectContext(ctx, &dest, "SELECT * FROM deployed_loan_parameters where network = $1 and version = $2 and address = $3 LIMIT 1", networkId, 0, address.Bytes())
-	if err != nil {
-		return nil, fmt.Errorf("when loading loan parameters from database: %v", err)
-	}
-	if len(dest) != 1 {
-		return nil, nil
-	}
-
-	return &dest[0], nil
-}
-
-// tableLoanMetadata is the description of an indexed Loan that we serve to
-// clients.
-type tableLoanMetadata struct {
-	Network         string `db:"network"`
-	ID              int64  `db:"loan_metadata_id"`
-	ShortID         string `db:"shortid"`
-	Borrower        []byte `db:"borrower"`
-	Description     string `db:"description"`
-	DeployedAddress []byte `db:"deployed_address"`
-}
-
-// Object returns an application-level LoanMetadata from a tableLoanMetadata.
-func (t *tableLoanMetadata) Object(m *Model) (*LoanMetadata, error) {
+func (t *fieldsLoanMetadata) Fill(l *Loan) error {
 	if t.Network == "" {
-		return nil, fmt.Errorf("Network not set")
+		return fmt.Errorf("Network not set")
 	}
 	if t.ShortID == "" {
-		return nil, fmt.Errorf("ShortID not set")
+		return fmt.Errorf("ShortID not set")
 	}
 	if len(t.Borrower) == 0 {
-		return nil, fmt.Errorf("Borrower not set")
+		return fmt.Errorf("Borrower not set")
 	}
 	if len(t.DeployedAddress) == 0 {
-		return nil, fmt.Errorf("DeployedAddress not set")
+		return fmt.Errorf("DeployedAddress not set")
 	}
-	deployed := ethcommon.BytesToAddress(t.DeployedAddress)
-	return &LoanMetadata{
-		model:           m,
-		network:         t.Network,
-		ShortID:         t.ShortID,
-		Borrower:        ethcommon.BytesToAddress(t.Borrower),
-		Description:     t.Description,
-		DeployedAddress: &deployed,
-	}, nil
+	l.Metadata.NetworkID = t.Network
+	l.Metadata.ShortID = t.ShortID
+	l.Metadata.Borrower = ethcommon.BytesToAddress(t.Borrower)
+	l.Metadata.Description = t.Description
+	l.Metadata.DeployedAddress = ethcommon.BytesToAddress(t.DeployedAddress)
+	return nil
 }
 
-type LoanMetadataQuery struct {
+type LoanQuery struct {
 	Network         string
 	ShortID         string
 	Borrower        *ethcommon.Address
 	DeployedAddress *ethcommon.Address
 }
 
-func (q LoanMetadataQuery) Run(ctx context.Context, m *Model) ([]LoanMetadata, error) {
-	data := []tableLoanMetadata{}
-	query := "SELECT * FROM loan_metadata"
-	keys := []string{}
-	args := []interface{}{}
-
-	if q.Network != "" {
-		keys = append(keys, "network")
-		args = append(args, q.Network)
-	}
-	if q.DeployedAddress != nil {
-		keys = append(keys, "deployed_address")
-		args = append(args, q.DeployedAddress.Bytes())
-	}
-	if q.Borrower != nil {
-		keys = append(keys, "borrower")
-		args = append(args, q.Borrower.Bytes())
-	}
-	if q.ShortID != "" {
-		keys = append(keys, "shortID")
-		args = append(args, q.ShortID)
+func buildWhere(keys []string) string {
+	if len(keys) == 0 {
+		return ""
 	}
 
 	where := []string{}
 	for i, key := range keys {
 		where = append(where, fmt.Sprintf("%s = $%d", key, i+1))
 	}
-	if len(keys) != 0 {
-		query = query + " WHERE " + strings.Join(where, " AND ")
+
+	return "WHERE " + strings.Join(where, " AND ")
+}
+
+func (q LoanQuery) Run(ctx context.Context, m *Model) ([]Loan, error) {
+	keys := []string{}
+	args := []interface{}{}
+
+	if q.Network != "" {
+		keys = append(keys, "meta.network")
+		args = append(args, q.Network)
+	}
+	if q.DeployedAddress != nil {
+		keys = append(keys, "meta.deployed_address")
+		args = append(args, q.DeployedAddress.Bytes())
+	}
+	if q.Borrower != nil {
+		keys = append(keys, "meta.borrower")
+		args = append(args, q.Borrower.Bytes())
+	}
+	if q.ShortID != "" {
+		keys = append(keys, "meta.shortid")
+		args = append(args, q.ShortID)
 	}
 
-	err := m.dbConn.SelectContext(ctx, &data, query, args...)
+	data, err := m.selectJoinedLoansMetadataParameters(ctx, keys, args)
 	if err != nil {
-		return []LoanMetadata{}, err
+		return []Loan{}, err
 	}
-
-	res := []LoanMetadata{}
-	for _, table := range data {
-		obj, err := table.Object(m)
-		if err != nil {
-			return []LoanMetadata{}, err
+	res := []Loan{}
+	for _, d := range data {
+		l := Loan{model: m}
+		if err := d.fieldsLoanMetadata.Fill(&l); err != nil {
+			glog.Warningf("when filling metadata from db: %v", err)
+			continue
 		}
-		res = append(res, *obj)
+
+		if err := d.fieldsDeployedLoanParameters.Fill(&l); err != nil {
+			glog.Warningf("when filling parameters from db: %v", err)
+			continue
+		}
+		res = append(res, l)
 	}
 
 	return res, nil
 }
 
-// TODO(q3k): refactor this to operate on the table struct instead
-func (d *LoanMetadata) Index(ctx context.Context) error {
-	if d.model == nil {
-		return fmt.Errorf("LoanMetadata has no model attached")
-	}
-	if d.network == "" {
-		return fmt.Errorf("LoanMetadata has no network specified")
-	}
-	if d.DeployedAddress == nil {
-		return fmt.Errorf("LoanMetadata has no deployed address specified")
-	}
-	if d.ShortID != "" {
-		return fmt.Errorf("LoanMetadata has ShortID set")
-	}
-
-	parameters, err := d.model.GetLoanParameters(ctx, d.network, *d.DeployedAddress)
-	if err != nil {
-		return fmt.Errorf("could not load loan parameters: %v", err)
-	}
-
-	tx, err := d.model.dbConn.Beginx()
-	if err != nil {
-		return err
-	}
-
+func (l *Loan) generateShortId(ctx context.Context, tx *sqlx.Tx) error {
 	// Generate unique shortID, ensure it's not duplicate in the database.
 	// This is somewhat hacky, even with the guarantees of the shortid library
 	// that we use.
+	var err error
 	tries := 0
 	shortID := ""
+
 	for {
 		tries += 1
 		if tries > 10 {
-			tx.Rollback()
 			return fmt.Errorf("could not generate shortid: %v", err)
 		}
 
@@ -264,43 +263,65 @@ func (d *LoanMetadata) Index(ctx context.Context) error {
 		}
 	}
 
-	_, err = tx.ExecContext(ctx, `
-INSERT INTO loan_metadata (
-	shortid, borrower, description, network, deployed_address
-) VALUES (
-	$1, $2, $3, $4, $5 
-)`, shortID, parameters.Borrower.Bytes(), d.Description, d.network, d.DeployedAddress.Bytes())
-	if err != nil {
-		tx.Rollback()
-		return fmt.Errorf("could not insert loan metadata: %v", err)
-	}
-
-	d.ShortID = shortID
-	return tx.Commit()
+	l.Metadata.ShortID = shortID
+	return nil
 }
 
-// TODO(q3k): refactor this to operate on the table struct instead
-func (d *DeployedLoanParameters) saveToDatabase(ctx context.Context) error {
-	t := tableDeployedLoanParameters{
-		Network: d.network,
-		Version: 0,
-		Address: d.address.Bytes(),
-
-		BorrowedToken:          d.BorrowedToken.Bytes(),
-		CollateralToken:        d.CollateralToken.Bytes(),
-		AmountWanted:           d.AmountWanted.String(),
-		Borrower:               d.Borrower.Bytes(),
-		InterestPermil:         d.InterestPermil,
-		FundraisingBlocksCount: d.FundraisingBlocksCount.String(),
-		PaybackBlocksCount:     d.PaybackBlocksCount.String(),
+func (l *Loan) UpsertMetadata(ctx context.Context, tx *sqlx.Tx) error {
+	var err error
+	if l.Metadata.ShortID == "" {
+		if err = l.generateShortId(ctx, tx); err != nil {
+			return err
+		}
 	}
-	_, err := d.model.dbConn.NamedExecContext(ctx, `
-INSERT INTO deployed_loan_parameters (
-	network, version, address,
-	borrowed_token, collateral_token, amount_wanted, borrower, interest_permil, fundraising_blocks_count, payback_blocks_count
-) VALUES (
-	:network, :version, :address,
-	:borrowed_token, :collateral_token, :amount_wanted, :borrower, :interest_permil, :fundraising_blocks_count, :payback_blocks_count
-)`, t)
+
+	// Currently we only modify the description for updated loans.
+	query := `
+		INSERT INTO loan_metadata (
+				shortid, borrower, description, network, deployed_address
+		)
+		VALUES (
+				:meta_shortid, :meta_borrower, :meta_description, :meta_network, :meta_deployed_address
+		)
+		ON CONFLICT (shortid) DO
+		UPDATE SET
+			description = :meta_description
+	`
+	_, err = l.model.dbConn.NamedExecContext(ctx, query, fieldsLoanMetadata{
+		ShortID:         l.Metadata.ShortID,
+		Network:         l.Metadata.NetworkID,
+		DeployedAddress: l.Metadata.DeployedAddress.Bytes(),
+		Borrower:        l.Metadata.Borrower.Bytes(),
+		Description:     l.Metadata.Description,
+	})
+	return err
+}
+
+func (l *Loan) InsertParameters(ctx context.Context, tx *sqlx.Tx) error {
+	query := `
+		INSERT INTO deployed_loan_parameters (
+				network, version, address,
+				borrowed_token, collateral_token, amount_wanted, borrower,
+				interest_permil, fundraising_blocks_count, payback_blocks_count
+		)
+		VALUES (
+				:params_network, :params_version, :params_address,
+				:params_borrowed_token, :params_collateral_token, :params_amount_wanted, :params_borrower,
+				:params_interest_permil, :params_fundraising_blocks_count, :params_payback_blocks_count
+		)
+	`
+	_, err := l.model.dbConn.NamedExecContext(ctx, query, fieldsDeployedLoanParameters{
+
+		Network:                l.Metadata.NetworkID,
+		Version:                0,
+		Address:                l.Metadata.DeployedAddress.Bytes(),
+		BorrowedToken:          l.Parameters.BorrowedToken.Bytes(),
+		CollateralToken:        l.Parameters.CollateralToken.Bytes(),
+		AmountWanted:           l.Parameters.AmountWanted.String(),
+		Borrower:               l.Parameters.Borrower.Bytes(),
+		InterestPermil:         l.Parameters.InterestPermil,
+		FundraisingBlocksCount: l.Parameters.FundraisingBlocksCount.String(),
+		PaybackBlocksCount:     l.Parameters.PaybackBlocksCount.String(),
+	})
 	return err
 }

--- a/metabackend/server/server.go
+++ b/metabackend/server/server.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"sync"
 
 	"golang.org/x/net/context"
 
@@ -135,7 +134,7 @@ func (s *Server) GetLoans(ctx context.Context, req *pb.GetLoansRequest) (*pb.Get
 		return nil, fmt.Errorf("no such network ID")
 	}
 
-	query := model.LoanMetadataQuery{
+	query := model.LoanQuery{
 		Network: network.ID,
 	}
 	if req.GetOwner() != nil {
@@ -156,59 +155,28 @@ func (s *Server) GetLoans(ctx context.Context, req *pb.GetLoansRequest) (*pb.Get
 	}
 
 	cache := make([]*pb.LoanCache, len(loans))
-	errors := make([]error, len(loans))
-	wg := sync.WaitGroup{}
-
-	glog.Infof("GetLoans: %d results", len(loans))
 	for i, loan := range loans {
-		loan := loan
-		wg.Add(1)
-		go func(loan *model.LoanMetadata, i int) {
-			defer wg.Done()
-
-			parameters, err := s.Model.GetLoanParameters(ctx, network.ID, *loan.DeployedAddress)
-			if err != nil {
-				errors[i] = fmt.Errorf("when getting loan %v: %v", loan.DeployedAddress.Hex(), err)
-				return
-			}
-			c := pb.LoanCache{
-				Owner:             util.ProtoAddress(loan.Borrower.Hex()),
-				DeploymentAddress: util.ProtoAddress(loan.DeployedAddress.Hex()),
-				ShortId:           loan.ShortID,
-				Parameters:        parameters.Proto(),
-				Description:       loan.Description,
-				DeploymentState:   pb.LoanCache_DEPLOYED,
-			}
-			cache[i] = &c
-		}(&loan, i)
-	}
-	wg.Wait()
-
-	for _, err := range errors {
-		if err == nil {
-			continue
+		c := pb.LoanCache{
+			Owner:             util.ProtoAddress(loan.Metadata.Borrower.Hex()),
+			DeploymentAddress: util.ProtoAddress(loan.Metadata.DeployedAddress.Hex()),
+			ShortId:           loan.Metadata.ShortID,
+			Parameters:        loan.ProtoParameters(),
+			Description:       loan.Metadata.Description,
+			DeploymentState:   pb.LoanCache_DEPLOYED,
 		}
-		glog.Errorf("Could not get loan parameters: %v", err)
-	}
-
-	cacheNoErrors := []*pb.LoanCache{}
-	for _, cacheElem := range cache {
-		if cacheElem == nil {
-			continue
-		}
-		cacheNoErrors = append(cacheNoErrors, cacheElem)
+		cache[i] = &c
 	}
 
 	res := &pb.GetLoansResponse{
 		NetworkId: network.ID,
-		LoanCache: cacheNoErrors,
+		LoanCache: cache,
 	}
 	return res, nil
 }
 
 func (s *Server) IndexLoan(ctx context.Context, req *pb.IndexLoanRequest) (*pb.IndexLoanResponse, error) {
 	networkId := req.GetNetworkId()
-	network, ok := s.Deployment.Networks[networkId]
+	_, ok := s.Deployment.Networks[networkId]
 	if !ok {
 		return nil, fmt.Errorf("no such network ID")
 	}
@@ -218,37 +186,42 @@ func (s *Server) IndexLoan(ctx context.Context, req *pb.IndexLoanRequest) (*pb.I
 		return nil, fmt.Errorf("invalid loan address specified: %v", err)
 	}
 
-	existing, err := model.LoanMetadataQuery{
-		Network:         network.ID,
-		DeployedAddress: &address,
-	}.Run(ctx, s.Model)
-	if err == nil && len(existing) != 0 {
-		return &pb.IndexLoanResponse{
-			existing[0].ShortID,
-		}, nil
-	}
-
-	invalid, err := s.Model.ValidLoan(ctx, network.ID, address)
+	tx, err := s.Model.Transaction()
 	if err != nil {
-		glog.Errorf("ValidLoan(..., %q, %q): %v", network.ID, address.Hex(), err)
+		glog.Errorf("When beginning transaction: %v", err)
 		return nil, fmt.Errorf("internal server error")
 	}
-	if invalid != "" {
-		return nil, fmt.Errorf("invalid loan specified: %s", invalid)
+	defer tx.Rollback()
+
+	loan := s.Model.NewLoan()
+	loan.Metadata.NetworkID = networkId
+	loan.Metadata.Description = req.GetDescription()
+	loan.Metadata.DeployedAddress = address
+
+	if err = loan.LoadParametersFromBlockchain(ctx); err != nil {
+		return nil, fmt.Errorf("invalid loan specified: %v", err)
 	}
 
-	md := model.NewLoanMetadata(s.Model, network.ID)
-	md.Description = req.GetDescription()
-	md.DeployedAddress = &address
+	loan.Metadata.Borrower = loan.Parameters.Borrower
 
-	err = md.Index(ctx)
+	if err = loan.UpsertMetadata(ctx, tx); err != nil {
+		glog.Errorf("When upserting metadata: %v", err)
+		return nil, fmt.Errorf("internal server error")
+	}
+
+	if err = loan.InsertParameters(ctx, tx); err != nil {
+		glog.Errorf("When inserting parameters: %v", err)
+		return nil, fmt.Errorf("internal server error")
+	}
+
+	err = tx.Commit()
 	if err != nil {
-		glog.Errorf("LoanMetadta.Index(..., %v, %v): %v", network.ID, address.Hex(), err)
+		glog.Errorf("When commiting transaction: %v", err)
 		return nil, fmt.Errorf("internal server error")
 	}
 
 	res := &pb.IndexLoanResponse{
-		md.ShortID,
+		loan.Metadata.ShortID,
 	}
 	return res, nil
 }

--- a/metabackend/server/server.go
+++ b/metabackend/server/server.go
@@ -75,9 +75,9 @@ func (s *Server) GetLoans(ctx context.Context, req *pb.GetLoansRequest) (*pb.Get
 		}
 		query.Borrower = &owner
 	}
-	if req.GetShortId() != "" {
-		query.ShortID = req.GetShortId()
-	}
+
+	query.ShortID = req.GetShortId()
+	query.State = req.GetState()
 
 	loans, err := query.Run(ctx, s.Model)
 	if err != nil {

--- a/pb/metabackend.proto
+++ b/pb/metabackend.proto
@@ -37,23 +37,22 @@ message Address {
 // GetLine Loan Cache //
 ////////////////////////
 
-// The state of a GetLine Loan contract, to be used as a cache.
-// See contract Solidity source for more information. This is returned
-// unopinionated, straight from the blockchain.
+// These are messages that represent data from the Loan smart contract. They're
+// unopinionated by the metabackend, even if cached.
+
+enum LoanLifetimeState {
+    INVALID = 0;
+
+    COLLATERAL_COLLECTION = 1;
+    FUNDRAISING = 2;
+    PAYBACK = 3;
+    FINISHED = 4;
+}
+
+// Collection of all data in the Loan contract that can change.
 message LoanState {
-    reserved 1, 2;
-    bytes fundraising_deadline = 3;
-    bytes payback_deadline = 4;
-
-    enum State {
-        INVALID = 0;
-
-        COLLATERAL_COLLECTION = 1;
-        FUNDRAISING = 2;
-        PAYBACK = 3;
-        FINISHED = 4;
-    }
-    State current_state = 5;
+    reserved 1, 2, 3, 4;
+    LoanLifetimeState lifetime_state = 5;
 }
 
 // Parameters with which a GetLine Loan was created.
@@ -172,6 +171,7 @@ message GetLoansRequest {
     Address owner = 2;
     // If set, filter by contract short ID.
     string short_id = 3;
+    LoanLifetimeState state = 4;
 }
 
 message GetLoansResponse {


### PR DESCRIPTION
We want to be able to query for loans by state, eg. all loans that can be invested into.

For this, we implement an additional metabackend GetLoans parameter, and add a new API (and tests) in getline.ts.

The current metabackend implementation  always polls the blockchain for status - this will obviously have to be either cached in memory or in the database at some point, but it's enough to ship a working implementation for the client to use.

Additionally, I refactored the metabackend SQL model code a bit to be less of a pain to work with.

We also bump the tsc lib to ES2016 in getline.ts (for `Array.prototype.includes`), which surprisingly broke some tests (seemingly by reordering arrays somewhere...), so we fix those to be less fragile.