### PR TITLE
Fix bignumber.js versioning discrepencies

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@types/jasmine": "^2.8.2",
     "@types/node": "^8.0.53",
-    "bignumber.js": "^4.1.0",
     "moment": "^2.19.2",
     "ts-loader": "^3.1.1",
     "ts-node": "^3.3.0",

--- a/frontend/src/api/collateral.ts
+++ b/frontend/src/api/collateral.ts
@@ -1,6 +1,4 @@
-import { BigNumber } from "bignumber.js";
-
-import API, { Loan } from './index';
+import API, { Loan, BigNumber } from './index';
 
 export async function gatherCollateral(shortId: string, amount) {
   const api = await API.instance();

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,7 +1,8 @@
 import API from './api';
-import { Client, Loan, LoanState } from '../../../getline.ts';
+import { BigNumber, Client, Loan, LoanState } from '../../../getline.ts';
 
 export { Loan, LoanState, Client };
+export { BigNumber };
 export * from './my-loans';
 export * from './demo-tokens';
 export * from './collateral';

--- a/frontend/src/api/invest.ts
+++ b/frontend/src/api/invest.ts
@@ -1,6 +1,4 @@
-import { BigNumber } from 'bignumber.js';
-
-import API, { LoanState } from './index';
+import API, { BigNumber, LoanState } from './index';
 import { LoanToInvestT } from '@/store/invest/types';
 import { getTokenSymbolsFromBlockchain, getAmountsWantedFromBlockchain, getAmountsGatheredFromBlockchain } from './utils';
 import { getSingleAmountWantedFromBlockchain, getSingleAmountGatheredFromBlockchain, getSingleTokenSymbolFromBlockchain } from './utils';

--- a/frontend/src/api/my-loans.ts
+++ b/frontend/src/api/my-loans.ts
@@ -1,5 +1,4 @@
-import API, { LoanState } from './index';
-import { BigNumber } from 'bignumber.js';
+import API, { LoanState, BigNumber } from './index';
 
 import { MyLoanT } from '../store/my-loans';
 import { getTokenSymbolsFromBlockchain, getAmountsWantedFromBlockchain, getAmountsGatheredFromBlockchain } from './utils';

--- a/frontend/src/api/utils.ts
+++ b/frontend/src/api/utils.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from 'bignumber.js';
+import { BigNumber } from './index';
 
 export async function getAmountsWantedFromBlockchain(loans): Promise<BigNumber[]> {
   const amountsWantedPromises: Promise<BigNumber>[] =

--- a/frontend/src/store/invest/mutations.ts
+++ b/frontend/src/store/invest/mutations.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue'
-import { BigNumber } from 'bignumber.js/bignumber';
 
 import { InvestStateT, LoanToInvestT } from './types';
+import { BigNumber } from '@/api/index';
 
 export const mutations = {
   'RECEIVE_LOANS_TO_INVEST': function (state: InvestStateT, { loans }: { loans: LoanToInvestT[] }): void {

--- a/frontend/src/store/invest/types.ts
+++ b/frontend/src/store/invest/types.ts
@@ -1,4 +1,5 @@
-import { BigNumber } from 'bignumber.js/bignumber';
+import { BigNumber } from '@/api/index';
+
 export interface InvestStateT {
   loansToInvest: LoanToInvestT[];
   isLoading: boolean;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -911,10 +911,6 @@ big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
 
-bignumber.js@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-4.1.0.tgz#db6f14067c140bd46624815a7916c92d9b6c24b1"
-
 binary-extensions@^1.0.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.10.0.tgz#9aeb9a6c5e88638aad171e167f5900abe24835d0"

--- a/getline.ts/package.json
+++ b/getline.ts/package.json
@@ -37,7 +37,7 @@
     "@types/debug": "^0.0.30",
     "@types/google-protobuf": "^3.2.5",
     "async-mutex": "^0.1.3",
-    "bignumber": "^1.1.0",
+    "bignumber.js": "^4.1.0",
     "debug": "^3.1.0",
     "google-protobuf": "^3.4.0",
     "grpc-web-client": "^0.3.1",

--- a/getline.ts/src/index.ts
+++ b/getline.ts/src/index.ts
@@ -2,3 +2,4 @@ export {Client} from "./client";
 export {Loan, LoanState} from "./loan";
 export {ProviderLocked, ProviderOnUnsupportedNetwork,
     ProviderInitializationError, UserVisibleError} from "./blockchain";
+export {BigNumber} from "bignumber.js";

--- a/getline.ts/yarn.lock
+++ b/getline.ts/yarn.lock
@@ -327,17 +327,9 @@ big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
 
-bignumber.js@^4.0.2:
+bignumber.js@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-4.1.0.tgz#db6f14067c140bd46624815a7916c92d9b6c24b1"
-
-"bignumber.js@git+https://github.com/frozeman/bignumber.js-nolookahead.git":
-  version "2.0.7"
-  resolved "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
-
-bignumber@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/bignumber/-/bignumber-1.1.0.tgz#e6ab0a743da5f3ea018e5c17597d121f7868c159"
 
 binary-extensions@^1.0.0:
   version "1.11.0"
@@ -3903,13 +3895,13 @@ web3-typescript-typings@^0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/web3-typescript-typings/-/web3-typescript-typings-0.7.2.tgz#5312bb786936a9c91381eee7af3d02ac21cf13b3"
   dependencies:
-    bignumber.js "^4.0.2"
+    bignumber.js "^4.1.0"
 
 web3@0.20.1:
   version "0.20.1"
   resolved "https://registry.yarnpkg.com/web3/-/web3-0.20.1.tgz#fb262e9ad71552167a6af012fdd420de017032f0"
   dependencies:
-    bignumber.js "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
+    bignumber.js "^4.1.0"
     crypto-js "^3.1.4"
     utf8 "^2.1.1"
     xhr2 "*"


### PR DESCRIPTION
This was noticed in a debugging session by balinskia & q3k.

 - The Frontend creates a BigNumber (from its' own module) and passes it to a getline.ts function.
 - Getline.ts takes this BigNumber and passes it as an argument to a web3.js contract call.
 - web3.js then checks arguments passed and removes them if they're objects but not BigNumbers (to detect transaction options passed as arguments... :hankey:  ). Our BigNumber is removed because both of the following checks fail:
     - `n instanceof BigNumber` -> fails because the passed BigNumber instance is not an instance of web3's BigNumber constructor
     - `n.constructor.name === "BigNumber"` -> fails because the passed BigNumber has its' class name mangled by UglifyJs
 - This causes the function call to fail becuase the number of expected arguments doesn't match the number of arguments passed to the call, as the BigNumber argument got removed.

There's two ways to fix this issue:

 - Make sure that web3.js and the frontend use the same version of the BigNumber constructor.
 - Stop mangling names in UglifyJs.

We opt for the first option, as disabling mangling grows our app bundle by around 15%. It also seems like a cleaner fix. To implement this, we make getline.ts export the BigNumber constructor to clients. We then make the frontend use this constructor.

Additionally, we bump web3.js to use the upstream BigNubmer library instead of their own fork of it. As far as I understand, this fork exists for the sole reason of compatibility with running web3.js under the Otto VM [1] (which we don't plan on supporting). 

We should just stop using the dumpster fire that is web3.js 0.1x...

[1] - https://github.com/ethereum/web3.js/issues/904#issuecomment-311360796