### PR TITLE
Disallow zero amount loans.

### DIFF
--- a/dapp/contracts/loans/Loan.sol
+++ b/dapp/contracts/loans/Loan.sol
@@ -51,6 +51,7 @@ contract Loan {
         uint256 _fundraisingBlocksCount,
         uint256 _paybackBlocksCount
     ) {
+        require(_amountWanted > 0);
         //require(_atestator.isVerified(_liege));
         
         ledger = InvestorLedger.openAccount(

--- a/getline.ts/src/client.ts
+++ b/getline.ts/src/client.ts
@@ -113,6 +113,9 @@ export class Client {
         if (paybackEnd.isBefore(fundraisingEnd)) {
             throw new Error("cannot place loan with payback deadline before fundraising deadline");
         }
+        if (amount.lte(0)) {
+            throw new Error("cannot place loan for non-positive amount");
+        }
 
         const currentBlock = (await this.blockchain.currentBlock()).toNumber();
         const blocksPerSecond = (1.0) / 15;
@@ -209,7 +212,9 @@ export class Client {
             loans.push(loan);
         });
         await Promise.all(promises);
-        return loans;
+        // Filter out invalid loan amounts - these should not end up being
+        // indexed, but some did before we started checking.
+        return loans.filter((loan: Loan) => loan.parameters.amountWanted.gt(0));
     }
 
     // TODO(q3k): Remove this after demo, require explicit initialization instead.

--- a/getline.ts/test/integration.ts
+++ b/getline.ts/test/integration.ts
@@ -267,4 +267,20 @@ class EndToEndTests {
             }
         }
     }
+
+    /**
+     * Checks if a loan is correctly rejected if invalid.
+     */
+    @test(timeout(30000), slow(15000)) async loanIndexRejectInvalid() {
+        const c = await this.createClient();
+        const user = await c.currentUser();
+
+        const description = "test loan";
+        const amount = new BigNumber(0);
+        const interestPermil = 50;
+        const fundraising = moment().add(7, 'days');
+        const payback = fundraising.add(7, 'days');
+
+        assert.isRejected(c.newLoan(description, amount, interestPermil, fundraising, payback), /non-positive amount/, "zero amount loan is rejected");
+    }
 }

--- a/metabackend/model/loans.go
+++ b/metabackend/model/loans.go
@@ -380,6 +380,10 @@ func (l *Loan) LoadParametersFromBlockchain(ctx context.Context) error {
 		}
 	}
 
+	if l.Parameters.AmountWanted.Cmp(big.NewInt(0)) != 1 {
+		return fmt.Errorf("loan has invalid amount")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
We:
 - perform a fast short-circuit check in the getline.ts library
 - additionally, require the amount to be non-zero in newly-created
   contracts
 - just in case, block adding such new loans to the index
 - and finally, filter returning such loans via getline.ts to handle old
   invalid loans