### PR TITLE
Fix collateral amount being sent

### DIFF
--- a/frontend/src/api/collateral.ts
+++ b/frontend/src/api/collateral.ts
@@ -5,5 +5,5 @@ export async function gatherCollateral(shortId: string, amount) {
   const token = api.testToken;
   const user = await api.currentUser();
   const loan = await api.loan(shortId);
-  await loan.sendCollateral(new BigNumber(amount));
+  await loan.sendCollateral(await token.integerize(new BigNumber(amount)));
 }


### PR DESCRIPTION
As is easy to spot in the code, we were sending whole tokens as an argument, instead of the smallest values.

... We really should have had different types for different balances (one for humanized, one for integral). And made that type dependent on the token type.